### PR TITLE
chore: vercel.json 설정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
vercel rewrites 설정 추가로 SPA 라우팅 지원

## 📌 PR 타입

> 변경된 사항과 관련해서 체크해주세요. (다중 선택 가능)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 스타일 수정
- [ ] 코드 수정
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: ()

<br /><br />

## 📋 상세 작업 내용

> 어떤 부분을 변경했는지 구체적으로 적어주세요.

`vercel.json`에 다음 rewrites 설정을 추가했습니다.
```json
  {
    "rewrites": [{ "source": "/(.*)", "destination": "/" }]
  }
```

브라우저에서 직접 접근 시 서버에서 404 응답이 발생했습니다. SPA 환경에서는 라우팅을 브라우저가 처리해야 하므로, 서버가 알 수 없는 경로에 대해서도 index.html을 반환하도록 설정이 필요했습니다. 이를 위해, vercel rewrites 기능을 사용해 이를 해결했습니다.