### PR TITLE
feat: 분석 기록 페이지 구현

### DIFF
--- a/src/components/contract-image-slide/ContractImageSlideHighlight.jsx
+++ b/src/components/contract-image-slide/ContractImageSlideHighlight.jsx
@@ -1,9 +1,3 @@
-/**
- * @typedef {Object} ContractAnalysisImageSlideProps
- * @property {{ id:string, previewUrl:string }[]} images 업로드된 이미지 목록
- * @property {import('react').RefObject<HTMLDivElement>[]} slideRefs 슬라이드 컨테이너 refs
- */
-
 import { Fragment, useState } from 'react'
 
 import { useImageNaturals } from '@/hooks/useImageNaturals'
@@ -16,6 +10,13 @@ import { OcrOverlayBox } from './OcrOverlayBox'
 import styles from './ContractAnalysisImageSlide.module.css'
 
 /**
+ * @typedef {Object} ContractAnalysisImageSlideProps
+ * @property {{ id:string, previewUrl:string }[]} images 업로드된 이미지 목록
+ * @property {import('react').RefObject<HTMLDivElement>[]} slideRefs 슬라이드 컨테이너 refs
+ * @property {boolean} [readOnly=false] 읽기 전용 여부
+ */
+
+/**
  * 계약서 번역 이미지 슬라이드 (하이라이트 모드)
  *
  * - 좌우 스크롤 캐러셀
@@ -26,7 +27,7 @@ import styles from './ContractAnalysisImageSlide.module.css'
  * @returns {JSX.Element}
  */
 
-export const ContractAnalysisImageSlideHighlight = ({ images, slideRefs }) => {
+export const ContractAnalysisImageSlideHighlight = ({ images, slideRefs, readOnly = false }) => {
   const [activeFieldId, setActiveFieldId] = useState(null)
   const { imageRefs, naturalSizes, handleImageLoad } = useImageNaturals()
 
@@ -74,6 +75,7 @@ export const ContractAnalysisImageSlideHighlight = ({ images, slideRefs }) => {
                     >
                       <HighlightedTextEditor
                         text={text}
+                        readOnly={readOnly}
                         onChange={(nextMarkedText) =>
                           updateHighlightedTextAndSync(pageKey, ocrIndex, nextMarkedText)
                         }

--- a/src/components/contract-image-slide/ContractImageSlideTranslation.jsx
+++ b/src/components/contract-image-slide/ContractImageSlideTranslation.jsx
@@ -13,6 +13,7 @@ import styles from './ContractAnalysisImageSlide.module.css'
  * @typedef {Object} ContractAnalysisImageSlideTranslationProps
  * @property {{ id:string, previewUrl:string }[]} images 업로드된 이미지 목록
  * @property {import('react').RefObject<HTMLDivElement>[]} slideRefs 슬라이드 컨테이너 refs
+ * @property {boolean} [readOnly=false] 읽기 전용 여부
  */
 
 /**
@@ -26,7 +27,7 @@ import styles from './ContractAnalysisImageSlide.module.css'
  * @returns {JSX.Element}
  */
 
-export const ContractAnalysisImageSlideTranslation = ({ images, slideRefs }) => {
+export const ContractAnalysisImageSlideTranslation = ({ images, slideRefs, readOnly = false }) => {
   const [activeFieldId, setActiveFieldId] = useState(null)
   const { imageRefs, naturalSizes, handleImageLoad } = useImageNaturals()
 
@@ -74,6 +75,7 @@ export const ContractAnalysisImageSlideTranslation = ({ images, slideRefs }) => 
                     >
                       <TranslationTextEditor
                         text={text}
+                        readOnly={readOnly}
                         onChange={(nextPlainText) =>
                           updateTranslationText(pageKey, ocrIndex, nextPlainText)
                         }

--- a/src/components/contract-image-slide/HighlightedTextEditor.jsx
+++ b/src/components/contract-image-slide/HighlightedTextEditor.jsx
@@ -12,7 +12,7 @@ import styles from './HighlightedTextEditor.module.css'
  * @typedef {Object} HighlightedTextEditorProps
  * @property {string} text [[w]]..[[/]] 마커 포함 원본 문자열
  * @property {(nextMarkedText: string) => void} [onChange] 블러 시 직렬화된 문자열 콜백
- * @property {string} [className] 추가 클래스명
+ * @property {boolean} [readOnly=false] 읽기 전용 여부
  * @property {import('react').HTMLAttributes<HTMLSpanElement>} [rest] span에 전달할 DOM 속성
  */
 

--- a/src/features/analysis-history/containers/AnalysisHistoryHighlight.jsx
+++ b/src/features/analysis-history/containers/AnalysisHistoryHighlight.jsx
@@ -1,0 +1,46 @@
+import { useRef } from 'react'
+
+import { ContractAnalysisImageSlideHighlight } from '@/components/contract-image-slide/ContractImageSlideHighlight'
+import { StepProgress } from '@/components/StepProgress/StepProgress'
+import { UnderlineText } from '@/components/UnderlineText/UnderlineText'
+import { ContractAnalysisDownloadButton } from '@/features/contract-analysis/components/ContractAnalysisDownloadButton'
+import { ContractAnalysisTooltip } from '@/features/contract-analysis/components/ContractAnalysisTooltip'
+import { useScrollSnap } from '@/features/contract-analysis/hooks/useScrollSnap'
+import { useHtml2CanvasBatch } from '@/hooks/useHtml2CanvasBatch'
+import { useStep } from '@/stores/useStep'
+
+import styles from './AnalysisHistoryHighlight.module.css'
+
+export const AnalysisHistoryHighlight = () => {
+  const carouselRef = useRef(null)
+  const slideRefs = [useRef(null), useRef(null), useRef(null)]
+
+  const { currentStep, setStep } = useStep()
+  const { downloadAll } = useHtml2CanvasBatch({ refs: slideRefs })
+
+  useScrollSnap(carouselRef, slideRefs, setStep)
+
+  return (
+    <div>
+      <header className={styles['header']}>
+        <h2>
+          <UnderlineText>키워드</UnderlineText>를 표시했어요!
+        </h2>
+        <h2>중요한 부분부터 확인해볼까요?</h2>
+      </header>
+
+      <p className={styles['description']}>
+        노란색은 중요한 내용, 파란색은 한 번 더 주의할 부분이에요.
+      </p>
+
+      <section ref={carouselRef} className={styles['analysis-section']}>
+        <ContractAnalysisImageSlideHighlight images={[]} slideRefs={slideRefs} />
+        <ContractAnalysisDownloadButton onDownload={downloadAll} />
+        <ContractAnalysisTooltip />
+        <div className={styles['progress']}>
+          <StepProgress currentStep={currentStep} />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/features/analysis-history/containers/AnalysisHistoryHighlight.module.css
+++ b/src/features/analysis-history/containers/AnalysisHistoryHighlight.module.css
@@ -1,0 +1,26 @@
+.header {
+  margin: 16px 36px 18px;
+  font-size: var(--font-common-title-size);
+  font-weight: var(--font-common-title-weight);
+}
+
+.analysis-section {
+  position: relative;
+  margin: 0 36px;
+  aspect-ratio: 16 / 23;
+}
+
+.progress {
+  position: absolute;
+  left: 67px;
+  right: 67px;
+  bottom: 12px;
+  z-index: 10;
+}
+
+.description {
+  margin: 12px 36px;
+  font-size: var(--font-list-detail-size);
+  font-weight: var(--font-list-detail-weight);
+  color: var(--color-sub-text);
+}

--- a/src/features/analysis-history/containers/AnalysisHistorySummary.jsx
+++ b/src/features/analysis-history/containers/AnalysisHistorySummary.jsx
@@ -1,0 +1,126 @@
+import { AnalysisSummarySection } from '@/components/analysis-summary-section/AnalysisSummarySection'
+import { Icon } from '@/components/Icon/Icon'
+import { UnderlineText } from '@/components/UnderlineText/UnderlineText'
+
+import styles from './AnalysisHistorySummary.module.css'
+
+const dummy = {
+  summary: [
+    {
+      title: '1. 계약 기본 정보',
+      subTitle: '임대인과 임차인 간의 주택 임대차 계약 주요 내용',
+      content: [
+        '임대인 ‘멋쟁이’와 임차인 ‘김사자’가 서울특별시 노원구 광운로 21 소재의 다가구주택 일부(면적 21㎡)를 대상으로 임대차 계약을 체결함.',
+        '계약 기간은 2025년 8월 21일부터 2027년 8월 21일까지이며, 보증금은 1,000만 원, 월세는 50만 원으로 책정됨.',
+        '계약금 200만 원은 계약 시 지급, 중도금 100만 원은 2025년 8월 21일 지급, 잔금 1,800만 원은 같은 날 지급.',
+        '관리비는 월 10만 원으로, 일반관리비·전기료·수도료·가스비·난방비·인터넷·TV사용료·기타 관리비 등 세부 항목이 명시됨.',
+      ],
+    },
+    {
+      title: '2. 유지·수선 및 사용 조건',
+      subTitle: '주택 사용, 수리, 비용 부담에 관한 합의',
+      content: [
+        '임대인은 계약 기간 동안 주택을 사용·수익 가능한 상태로 유지해야 하며, 임차인은 주거 외 용도로 사용하거나 구조 변경, 전대, 임차권 양도를 할 수 없음.',
+        '주요 설비(난방, 전기, 수도 등)의 노후·불량에 따른 수선은 임대인 부담, 임차인의 과실로 인한 파손이나 소모품 교체는 임차인 부담.',
+        '입주 전 세면대 수리를 하기로 합의했으며, 잔금 지급일인 2025년 9월까지 완료 예정.',
+      ],
+    },
+    {
+      title: '3. 계약 해제·해지 조건',
+      subTitle: '계약을 종료하거나 갱신하지 않는 조건',
+      content: [
+        '중도금 또는 잔금 지급 전에는 계약금 배액 상환(임대인) 또는 계약금 포기(임차인)로 해제 가능.',
+        '임차인은 과실 없이 주택 일부가 멸실되거나 사용 불가 시 해지 가능.',
+        '임대인은 임차인이 2기분 월세 연체 또는 무단 구조변경·전대 시 해지 가능.',
+        '임차인은 계약 종료 6개월 전부터 2개월 전까지 계약 갱신을 요구할 수 있으며, 법에서 정한 사유 외 거절 불가.',
+      ],
+    },
+    {
+      title: '4. 특약 사항',
+      subTitle: '추가로 합의한 조건',
+      content: [
+        '임차인은 2025년 9월 2일까지 전입신고를 완료해야 하며, 임대인은 그 다음날까지 담보권 설정 불가.',
+        '임대인이 특약을 위반해 담보권 설정 시, 임차인은 계약 해제 및 손해배상 청구 가능.',
+        '임차인은 임대인이 사전 고지하지 않은 금전 또는 물건을 요구받을 경우 계약 해제 가능.',
+      ],
+    },
+  ],
+  warning: [
+    {
+      title: '1. 전세금·월세 지급 관련 주의',
+      subTitle: '계약금, 중도금, 잔금, 월세 지급 시기와 방식 확인 필요',
+      content: [
+        '중도금과 잔금 지급일이 동일(2025년 8월 21일)로 설정되어 있어, 실제 지급 일정과 혼동 가능성 있음.',
+        '계약금·중도금·잔금 지급 내역은 반드시 영수증 등 증빙 자료로 남겨야 함.',
+      ],
+    },
+    {
+      title: '2. 관리비 항목 세부 확인 필요',
+      subTitle: '관리비 고정 금액 외 추가 비용 발생 가능성',
+      content: [
+        '관리비 총액 10만 원에 세부 항목이 명시되어 있으나, ‘기타 관리비’ 명목으로 추가 부과 가능성이 있음.',
+        '정액이 아닌 경우 사용량 비례 관리비 산정 방식이 모호하므로, 실제 부과 기준을 명확히 해야 함.',
+      ],
+    },
+    {
+      title: '3. 계약 해지·갱신 조건',
+      subTitle: '법정 해지 사유와 특약 조건 차이 유의',
+      content: [
+        "계약 해지 사유 중 '2기분 월세 연체'나 '무단 구조 변경'은 임대인의 즉시 해지 사유가 됨.",
+        '계약 갱신 거절 사유가 법에 따라 제한되지만, 특약에서 불리하게 합의될 가능성 있음.',
+      ],
+    },
+    {
+      title: '4. 특약 위반 시 손해배상',
+      subTitle: '담보권 설정 및 사전 고지 위반에 따른 리스크',
+      content: [
+        '임대인이 전입신고 기한 전에 담보권 설정 시, 임차인의 계약 해제 및 손해배상 청구 가능하지만 실제 집행 과정에서 분쟁 가능성 있음.',
+        '사전 고지 없이 금전·물건을 요구한 경우 계약 해제가 가능하나, 이를 입증하기 어려울 수 있음.',
+      ],
+    },
+    {
+      title: '5. 수리 합의 사항',
+      subTitle: '세면대 수리 기한과 완료 여부 확인 필요',
+      content: [
+        '세면대 수리를 2025년 9월까지 완료하기로 했으나, 구체적인 날짜와 품질 기준이 없어 분쟁 가능성 존재.',
+        '수리 완료 후 확인 절차 및 기록을 남겨야 함.',
+      ],
+    },
+  ],
+}
+
+export const AnalysisHistorySummary = () => {
+  const { summary, warning } = dummy
+
+  return (
+    <div className={styles['container']}>
+      <section className={styles['important-section']}>
+        <header className={styles['header']}>
+          <Icon name='bookmark' width={34} height={50} />
+          <div>
+            <h2>
+              <UnderlineText>핵심만</UnderlineText> 쏙 모았어요.
+            </h2>
+            <h2>우리 먼저 여기부터 체크해요!</h2>
+          </div>
+        </header>
+
+        <AnalysisSummarySection items={summary} />
+      </section>
+
+      <section className={styles['warning-section']}>
+        <header className={styles['header']}>
+          <Icon name='warning' width={37} height={49} />
+          <div>
+            <h2>
+              <UnderlineText>놓치지 쉬운 부분</UnderlineText>이에요.
+            </h2>
+            <h2>가기 전에 한 번 더 확인해요!</h2>
+          </div>
+        </header>
+
+        <AnalysisSummarySection items={warning} />
+      </section>
+    </div>
+  )
+}

--- a/src/features/analysis-history/containers/AnalysisHistorySummary.module.css
+++ b/src/features/analysis-history/containers/AnalysisHistorySummary.module.css
@@ -1,0 +1,25 @@
+.container {
+  margin-top: 16px;
+}
+
+.important-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.warning-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 16px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 36px;
+  font-size: var(--font-common-title-size);
+  font-weight: var(--font-common-title-weight);
+}

--- a/src/features/analysis-history/containers/AnalysisHistoryTranslate.jsx
+++ b/src/features/analysis-history/containers/AnalysisHistoryTranslate.jsx
@@ -1,0 +1,42 @@
+import { useRef } from 'react'
+
+import { ContractAnalysisImageSlideTranslation } from '@/components/contract-image-slide/ContractImageSlideTranslation'
+import { StepProgress } from '@/components/StepProgress/StepProgress'
+import { UnderlineText } from '@/components/UnderlineText/UnderlineText'
+import { ContractAnalysisDownloadButton } from '@/features/contract-analysis/components/ContractAnalysisDownloadButton'
+import { ContractAnalysisTooltip } from '@/features/contract-analysis/components/ContractAnalysisTooltip'
+import { useScrollSnap } from '@/features/contract-analysis/hooks/useScrollSnap'
+import { useHtml2CanvasBatch } from '@/hooks/useHtml2CanvasBatch'
+import { useStep } from '@/stores/useStep'
+
+import styles from './AnalysisHistoryTranslate.module.css'
+
+export const AnalysisHistoryTranslate = () => {
+  const carouselRef = useRef(null)
+  const slideRefs = [useRef(null), useRef(null), useRef(null)]
+
+  const { currentStep, setStep } = useStep()
+  const { downloadAll } = useHtml2CanvasBatch({ refs: slideRefs })
+
+  useScrollSnap(carouselRef, slideRefs, setStep)
+
+  return (
+    <div>
+      <header className={styles['header']}>
+        <h2>
+          한집말이가 <UnderlineText>번역</UnderlineText>을 했어요!
+        </h2>
+        <h2>같이 꼼꼼하게 확인해볼까요?</h2>
+      </header>
+
+      <section ref={carouselRef} className={styles['analysis-section']}>
+        <ContractAnalysisImageSlideTranslation images={[]} slideRefs={slideRefs} readOnly />
+        <ContractAnalysisDownloadButton onDownload={downloadAll} />
+        <ContractAnalysisTooltip />
+        <div className={styles['progress']}>
+          <StepProgress currentStep={currentStep} />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/features/analysis-history/containers/AnalysisHistoryTranslate.module.css
+++ b/src/features/analysis-history/containers/AnalysisHistoryTranslate.module.css
@@ -1,0 +1,19 @@
+.header {
+  margin: 16px 36px 18px;
+  font-size: var(--font-common-title-size);
+  font-weight: var(--font-common-title-weight);
+}
+
+.analysis-section {
+  position: relative;
+  margin: 0 36px;
+  aspect-ratio: 16 / 23;
+}
+
+.progress {
+  position: absolute;
+  left: 67px;
+  right: 67px;
+  bottom: 12px;
+  z-index: 10;
+}

--- a/src/features/analysis-history/pages/AnalysisHistory.jsx
+++ b/src/features/analysis-history/pages/AnalysisHistory.jsx
@@ -1,13 +1,14 @@
 import { useRef } from 'react'
 import cx from 'classnames'
 
+import { BackButton } from '@/components/BackButton/BackButton'
 import { ScrollToTopButton } from '@/components/ScrollToTopButton/ScrollToTopButton'
-import { ContractAnalysisSummary } from '@/features/contract-analysis/containers/ContractAnalysisSummary'
 import { useScrollSnap } from '@/features/contract-analysis/hooks/useScrollSnap'
 import { DocumentAnalysisProvider } from '@/stores/DocumentAnalysisProvider'
 import { useStep } from '@/stores/useStep'
 
 import { AnalysisHistoryHighlight } from '../containers/AnalysisHistoryHighlight'
+import { AnalysisHistorySummary } from '../containers/AnalysisHistorySummary'
 import { AnalysisHistoryTranslate } from '../containers/AnalysisHistoryTranslate'
 
 import styles from './AnalysisHistory.module.css'
@@ -22,38 +23,44 @@ export const AnalysisHistory = () => {
 
   return (
     <DocumentAnalysisProvider>
-      <div className={styles['background']} />
-      <div ref={carouselRef} className={styles['carousel-container']}>
-        <section
-          ref={slideRefs[0]}
-          className={cx(styles['carousel-item'], styles['snap-item'])}
-          data-index={1}
-          aria-label={'번역 섹션'}
-        >
-          <AnalysisHistoryTranslate />
-        </section>
+      <div className={styles['container']}>
+        <div className={styles['background']} />
+        <nav className={styles['back-button']}>
+          <BackButton />
+        </nav>
 
-        <section
-          ref={slideRefs[1]}
-          className={cx(styles['carousel-item'], styles['snap-item'])}
-          data-index={2}
-          aria-label={'하이라이트 섹션'}
-        >
-          <AnalysisHistoryHighlight />
-        </section>
+        <div ref={carouselRef} className={styles['carousel-container']}>
+          <section
+            ref={slideRefs[0]}
+            className={cx(styles['carousel-item'], styles['snap-item'])}
+            data-index={1}
+            aria-label={'번역 섹션'}
+          >
+            <AnalysisHistoryTranslate />
+          </section>
 
-        <section
-          ref={slideRefs[2]}
-          className={styles['carousel-item']}
-          data-index={3}
-          aria-label={'요약 섹션'}
-        >
-          <ContractAnalysisSummary containerRef={carouselRef} />
+          <section
+            ref={slideRefs[1]}
+            className={cx(styles['carousel-item'], styles['snap-item'])}
+            data-index={2}
+            aria-label={'하이라이트 섹션'}
+          >
+            <AnalysisHistoryHighlight />
+          </section>
 
-          <div className={styles['scroll-button']}>
-            <ScrollToTopButton targetRef={carouselRef} />
-          </div>
-        </section>
+          <section
+            ref={slideRefs[2]}
+            className={styles['carousel-item']}
+            data-index={3}
+            aria-label={'요약 섹션'}
+          >
+            <AnalysisHistorySummary containerRef={carouselRef} />
+
+            <div className={styles['scroll-button']}>
+              <ScrollToTopButton targetRef={carouselRef} />
+            </div>
+          </section>
+        </div>
       </div>
     </DocumentAnalysisProvider>
   )

--- a/src/features/analysis-history/pages/AnalysisHistory.jsx
+++ b/src/features/analysis-history/pages/AnalysisHistory.jsx
@@ -1,3 +1,60 @@
+import { useRef } from 'react'
+import cx from 'classnames'
+
+import { ScrollToTopButton } from '@/components/ScrollToTopButton/ScrollToTopButton'
+import { ContractAnalysisSummary } from '@/features/contract-analysis/containers/ContractAnalysisSummary'
+import { useScrollSnap } from '@/features/contract-analysis/hooks/useScrollSnap'
+import { DocumentAnalysisProvider } from '@/stores/DocumentAnalysisProvider'
+import { useStep } from '@/stores/useStep'
+
+import { AnalysisHistoryHighlight } from '../containers/AnalysisHistoryHighlight'
+import { AnalysisHistoryTranslate } from '../containers/AnalysisHistoryTranslate'
+
+import styles from './AnalysisHistory.module.css'
+
 export const AnalysisHistory = () => {
-  return <div>AnalysisHistory</div>
+  const carouselRef = useRef(null)
+  const slideRefs = [useRef(null), useRef(null), useRef(null)]
+
+  const { setStep } = useStep()
+
+  useScrollSnap(carouselRef, slideRefs, setStep)
+
+  return (
+    <DocumentAnalysisProvider>
+      <div className={styles['background']} />
+      <div ref={carouselRef} className={styles['carousel-container']}>
+        <section
+          ref={slideRefs[0]}
+          className={cx(styles['carousel-item'], styles['snap-item'])}
+          data-index={1}
+          aria-label={'번역 섹션'}
+        >
+          <AnalysisHistoryTranslate />
+        </section>
+
+        <section
+          ref={slideRefs[1]}
+          className={cx(styles['carousel-item'], styles['snap-item'])}
+          data-index={2}
+          aria-label={'하이라이트 섹션'}
+        >
+          <AnalysisHistoryHighlight />
+        </section>
+
+        <section
+          ref={slideRefs[2]}
+          className={styles['carousel-item']}
+          data-index={3}
+          aria-label={'요약 섹션'}
+        >
+          <ContractAnalysisSummary containerRef={carouselRef} />
+
+          <div className={styles['scroll-button']}>
+            <ScrollToTopButton targetRef={carouselRef} />
+          </div>
+        </section>
+      </div>
+    </DocumentAnalysisProvider>
+  )
 }

--- a/src/features/analysis-history/pages/AnalysisHistory.jsx
+++ b/src/features/analysis-history/pages/AnalysisHistory.jsx
@@ -1,0 +1,3 @@
+export const AnalysisHistory = () => {
+  return <div>AnalysisHistory</div>
+}

--- a/src/features/analysis-history/pages/AnalysisHistory.module.css
+++ b/src/features/analysis-history/pages/AnalysisHistory.module.css
@@ -1,3 +1,10 @@
+.container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .background {
   position: absolute;
   width: 100%;
@@ -5,6 +12,10 @@
   background-color: var(--color-secondary-bg);
   border-radius: 0 0 32px 32px;
   z-index: -1;
+}
+
+.back-button {
+  margin: 48px 16px 0;
 }
 
 .carousel-container {

--- a/src/features/analysis-history/pages/AnalysisHistory.module.css
+++ b/src/features/analysis-history/pages/AnalysisHistory.module.css
@@ -1,0 +1,30 @@
+.background {
+  position: absolute;
+  width: 100%;
+  height: 283px;
+  background-color: var(--color-secondary-bg);
+  border-radius: 0 0 32px 32px;
+  z-index: -1;
+}
+
+.carousel-container {
+  position: relative;
+  height: calc(100svh - 82.5px);
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.carousel-item {
+  scroll-snap-align: start;
+  display: flex;
+  flex-direction: column;
+}
+
+.snap-item {
+  height: calc(100svh - 82.5px);
+}
+
+.scroll-button {
+  margin: 14px 16px 60px auto;
+}

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom'
 
+import { AnalysisHistory } from '../features/analysis-history/pages/AnalysisHistory'
 import { ContractAnalysis } from '../features/contract-analysis/pages/ContractAnalysis'
 import { ListLawyer } from '../features/list-lawyer/pages/ListLawyer'
 import { ListSite } from '../features/list-site/pages/ListSite'
@@ -13,6 +14,7 @@ const routes = [
   { path: ROUTES.MYPAGE, element: <MyPage /> },
   { path: ROUTES.LIST_SITE, element: <ListSite /> },
   { path: ROUTES.LIST_LAWYER, element: <ListLawyer /> },
+  { path: ROUTES.ANALYSIS_HISTORY, element: <AnalysisHistory /> },
 ]
 
 export const AppRouter = () => {

--- a/src/router/routes.constant.js
+++ b/src/router/routes.constant.js
@@ -4,4 +4,5 @@ export const ROUTES = Object.freeze({
   MYPAGE: '/mypage',
   LIST_SITE: '/list-site',
   LIST_LAWYER: '/list-lawyer',
+  ANALYSIS_HISTORY: '/analysis-history',
 })


### PR DESCRIPTION
## 📌 PR 타입

> 변경된 사항과 관련해서 체크해주세요. (다중 선택 가능)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 스타일 수정
- [ ] 코드 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: ()

<br /><br />

## 📋 상세 작업 내용

> 어떤 부분을 변경했는지 구체적으로 적어주세요.

분석 기록 페이지 구현했습니다. 기존 계약서 분석 결과 페이지와 동일하되, `readonly` 속성을 통해서 수정이 불가능하도록 하였습니다.

한가지 신경써야할 부분은
- 계약서 분석 결과 페이지: 각 슬라이드별 AI에게 데이터 요청을 보냄
- 분석 기록 페이지의 경우: 서버에서 한번에 전체 데이터를 받고 이를 내려줌

따라서, 서버와의 연결에서 데이터 관리에 신경쓸 필요가 있습니다.